### PR TITLE
lock out dependencies on any containing directories' .babelrc or babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,2 +1,3 @@
 {
+  breakConfig: true
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "url": "git://github.com/prosemirror/prosemirror.git"
   },
   "dependencies": {
-    "markdown-it": "^4.0.0"
+    "markdown-it": "^4.0.0",
+    "babel": "^5.1.13"
   },
   "devDependencies": {
     "xmldom": "^0.1.0",
-    "babel": "^5.1.13",
     "babelify": "^6.0.2",
     "watchify": "^3.2.0",
     "blint": "^0.4.0"
@@ -28,7 +28,7 @@
     "test": "node test/start.js",
     "demo": "watchify -d -v --outfile demo/demo-built.js -t babelify demo/demo.js",
     "browsertests": "watchify -d -v --outfile demo/test-built.js -t babelify demo/test.js",
-    "dist": "babel --babelrc=.babelrc -d dist src",
+    "dist": "./node_modules/babel/bin/babel.js --babelrc=.babelrc -d dist src",
     "dist-watch": "babel -w -d dist src",
     "lint": "blint --browser --ecmaVersion 6 --forbidSemicolons src"
   }


### PR DESCRIPTION
Ugly, but works for now.
